### PR TITLE
feat(transactions): filter transactions by supported tokenIds

### DIFF
--- a/src/tokens/constants.ts
+++ b/src/tokens/constants.ts
@@ -1,0 +1,3 @@
+import networkConfig from 'src/web3/networkConfig'
+
+export const ALLOWED_TOKEN_IDS = new Set([networkConfig.cusdTokenId, networkConfig.ckesTokenId])

--- a/src/tokens/saga.ts
+++ b/src/tokens/saga.ts
@@ -4,6 +4,7 @@ import { AppEvents } from 'src/analytics/Events'
 import { DOLLAR_MIN_AMOUNT_ACCOUNT_FUNDED } from 'src/config'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
+import { ALLOWED_TOKEN_IDS } from 'src/tokens/constants'
 import {
   importedTokensSelector,
   lastKnownTokenBalancesSelector,
@@ -109,9 +110,8 @@ export async function getTokensInfo(): Promise<StoredTokenBalances> {
     )
   }
   const rawTokens = await response.json()
-  const allowedTokenIds = [networkConfig.ckesTokenId, networkConfig.cusdTokenId]
   return Object.keys(rawTokens)
-    .filter((tokenId) => allowedTokenIds.includes(tokenId))
+    .filter((tokenId) => ALLOWED_TOKEN_IDS.has(tokenId))
     .reduce((acc, tokenId) => {
       acc[tokenId] = rawTokens[tokenId]
       return acc

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -13,6 +13,7 @@ import { useDispatch, useSelector } from 'src/redux/hooks'
 import { AppDispatch, store } from 'src/redux/store'
 import { getMultichainFeatures } from 'src/statsig/index'
 import { vibrateSuccess } from 'src/styles/hapticFeedback'
+import { ALLOWED_TOKEN_IDS } from 'src/tokens/constants'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import {
@@ -32,7 +33,7 @@ import {
 } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { gql } from 'src/utils/gql'
-import { default as config, default as networkConfig } from 'src/web3/networkConfig'
+import { default as config } from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 const MIN_NUM_TRANSACTIONS = 10
@@ -576,9 +577,7 @@ export function isTransactionEligible(transaction: TokenTransaction) {
       return false
   }
 
-  // TODO(satish): find a shared place to store the allowed tokenIds
-  const allowedTokenIds = [networkConfig.ckesTokenId, networkConfig.cusdTokenId]
-  return tokenIds.every((tokenId) => allowedTokenIds.includes(tokenId))
+  return tokenIds.every((tokenId) => ALLOWED_TOKEN_IDS.has(tokenId))
 }
 
 export const TRANSACTIONS_QUERY = gql`


### PR DESCRIPTION
### Description

Filter to only send / receive / swap / approval transactions and if they involve the supported token ids

### Test plan

Unit tests, manually by checking the activity tab

### Related issues

- Part of ACT-1434

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
