### PR TITLE
feat: only support celo networks

### DIFF
--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -46,7 +46,7 @@ export const DynamicConfigs = {
       showSwap: [networkConfig.defaultNetworkId],
       showTransfers: [networkConfig.defaultNetworkId],
       showWalletConnect: [networkConfig.defaultNetworkId],
-      showApprovalTxsInHomefeed: [] as NetworkId[],
+      showApprovalTxsInHomefeed: [networkConfig.defaultNetworkId],
       showNfts: [networkConfig.defaultNetworkId],
       showPositions: [networkConfig.defaultNetworkId],
       showShortcuts: [networkConfig.defaultNetworkId],

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -16,10 +16,9 @@ import {
   StatsigFeatureGates,
   StatsigMultiNetworkDynamicConfig,
 } from 'src/statsig/types'
-import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { EvaluationReason } from 'statsig-js'
-import { DynamicConfig, Statsig } from 'statsig-react-native'
+import { Statsig } from 'statsig-react-native'
 import { getMockStoreData } from 'test/utils'
 
 jest.mock('src/redux/store', () => ({ store: { getState: jest.fn() } }))
@@ -131,83 +130,11 @@ describe('Statsig helpers', () => {
   })
 
   describe('getMultichainFeatures', () => {
-    it('returns default values if getting statsig dynamic config throws error', () => {
-      jest.mocked(Statsig.getConfig).mockImplementation(() => {
-        throw new Error('mock error')
-      })
+    it('returns default values', () => {
       const defaultValues =
         DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES].defaultValues
       const output = getMultichainFeatures()
-      expect(Logger.warn).toHaveBeenCalled()
       expect(output).toEqual(defaultValues)
-    })
-    it('filters out invalid NetworkIds', () => {
-      const defaultValues =
-        DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES].defaultValues
-      const getMock = jest
-        .fn()
-        .mockImplementation((paramName: keyof typeof defaultValues, _defaultValue: string) => {
-          if (paramName === 'showCico') {
-            return [NetworkId['arbitrum-one'], NetworkId['base-mainnet']]
-          } else if (paramName === 'showBalances') {
-            // celo is not a valid network id
-            return [NetworkId['ethereum-mainnet'], 'celo']
-          } else {
-            return DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES]
-              .defaultValues[paramName]
-          }
-        })
-      jest.mocked(Statsig.getConfig).mockImplementation(
-        () =>
-          ({
-            get: getMock,
-            getEvaluationDetails: () => ({ reason: EvaluationReason.Network }),
-          }) as unknown as DynamicConfig
-      )
-      const output = getMultichainFeatures()
-      expect(Logger.warn).not.toHaveBeenCalled()
-      expect(output).toEqual({
-        ...DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES].defaultValues,
-        showCico: [NetworkId['arbitrum-one'], NetworkId['base-mainnet']],
-        showBalances: [NetworkId['ethereum-mainnet']],
-      })
-      expect(Statsig.getConfig).toHaveBeenCalledWith(
-        StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES
-      )
-    })
-    it('returns values and logs error if sdk uninitialized', () => {
-      const defaultValues =
-        DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES].defaultValues
-      const getMock = jest
-        .fn()
-        .mockImplementation((paramName: keyof typeof defaultValues, _defaultValue: string) => {
-          if (paramName === 'showCico') {
-            return [NetworkId['arbitrum-one'], NetworkId['base-mainnet']]
-          } else if (paramName === 'showBalances') {
-            // celo is not a valid network id
-            return [NetworkId['ethereum-mainnet'], 'celo']
-          } else {
-            return DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES]
-              .defaultValues[paramName]
-          }
-        })
-      jest.mocked(Statsig.getConfig).mockImplementation(
-        () =>
-          ({
-            get: getMock,
-            getEvaluationDetails: () => ({ reason: EvaluationReason.Network }),
-          }) as unknown as DynamicConfig
-      )
-      const output = getMultichainFeatures()
-      expect(Logger.warn).not.toHaveBeenCalled()
-      expect(output).toEqual({
-        ...DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES].defaultValues,
-        showCico: [NetworkId['arbitrum-one'], NetworkId['base-mainnet']],
-        showBalances: [NetworkId['ethereum-mainnet']],
-      })
-      expect(Statsig.getConfig).toHaveBeenCalledWith(
-        StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES
-      )
     })
   })
 

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -11,6 +11,7 @@ import {
   StatsigMultiNetworkDynamicConfig,
   StatsigParameter,
 } from 'src/statsig/types'
+import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { EvaluationReason } from 'statsig-js'
@@ -87,7 +88,7 @@ function _getDynamicConfigParams<T extends Record<string, StatsigParameter>>({
   }
 }
 
-export function getMultichainFeatures() {
+export function getMultichainFeatures(): Record<string, NetworkId[]> {
   // just use defaults, which is celo
   return DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES].defaultValues
 }

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -11,7 +11,6 @@ import {
   StatsigMultiNetworkDynamicConfig,
   StatsigParameter,
 } from 'src/statsig/types'
-import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { EvaluationReason } from 'statsig-js'
@@ -89,14 +88,8 @@ function _getDynamicConfigParams<T extends Record<string, StatsigParameter>>({
 }
 
 export function getMultichainFeatures() {
-  const multichainParams = _getDynamicConfigParams(
-    DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES]
-  )
-  const filteredParams = {} as { [key: string]: NetworkId[] }
-  Object.entries(multichainParams).forEach(([key, value]) => {
-    filteredParams[key] = value.filter((networkId) => networkId in NetworkId)
-  })
-  return filteredParams
+  // just use defaults, which is celo
+  return DynamicConfigs[StatsigMultiNetworkDynamicConfig.MULTI_CHAIN_FEATURES].defaultValues
 }
 
 // Cannot be used to retrieve dynamic config for multichain features


### PR DESCRIPTION
### Description

Removes dependency on statsig and just uses the default values. 

### Test plan

- Ensure tokens / activity feed / send / swap flows show the right tokens
- Ensure only Celo shows up in the wallet address page in settings

### Related issues

- Part of ACT-1450

### Backwards compatibility

Y

### Network scalability

N/A
