### PR TITLE
feat: disable wallet connect

### DIFF
--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -10,7 +10,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   celoNews: string
 } = {
   inviteRewardsVersion: 'none',
-  walletConnectV2Enabled: true,
+  walletConnectV2Enabled: false,
   pincodeUseExpandedBlocklist: false,
   logPhoneNumberTypeEnabled: false,
   allowOtaTranslations: false,


### PR DESCRIPTION
### Description

Disables wallet connect firebase default. This will make it so that the app no longer is able to be used with wallet connect, and "Connected Dapps" section is not shown in settings. In case this needs to be turned on again after the app is released, we'll need a migration, because firebase defaults are only used the first time the app is installed, which is then stored in redux. The default values are never updated on redux, even if it changes. Maybe this is a wider issue we have to address in MS runtime

### Test plan

Make a fresh install of the app (as mentioned above, the change in defaults won't update redux) and ensure walletconnect qr scan doesn't work, and "Connected Dapps" is not shown in settings

### Related issues

- Fixes ACT-1450

### Backwards compatibility

Y

### Network scalability

N/A
