### PR TITLE
fix: tab layouts

### DIFF
--- a/src/home/TabActivity.tsx
+++ b/src/home/TabActivity.tsx
@@ -57,7 +57,7 @@ function TabActivity(_props: Props) {
   const sections = [transactionFeedSection]
 
   return (
-    <SafeAreaView testID="WalletHome" edges={[]}>
+    <SafeAreaView testID="WalletHome" edges={[]} style={{ flex: 1 }}>
       <AnimatedSectionList
         // Workaround iOS setting an incorrect automatic inset at the top
         scrollIndicatorInsets={{ top: 0.01 }}

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -31,6 +31,7 @@ import { initializeSentryUserContext } from 'src/sentry/actions'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import variables from 'src/styles/variables'
 import { useCashOutTokens, useCKES, useCUSD } from 'src/tokens/hooks'
 import { hasGrantedContactsPermission } from 'src/utils/contacts'
 
@@ -300,7 +301,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     position: 'relative',
-    paddingHorizontal: Spacing.Regular16,
+    padding: variables.contentPadding,
     gap: Spacing.Regular16,
   },
   flatCard: {


### PR DESCRIPTION
### Description

Fixes two small layout issues:
- Tab Activity cropping getting started section on pull
- Tab Home padding not matching other home tab padding.

### Test plan

- [x] Tested locally on iOS
- [x] Tested locally on Android

| iOS Before | iOS Afrer | 
| ----- | ----- |
| <video src="https://github.com/user-attachments/assets/6438826c-b5d8-4435-b10a-5207dccea1eb" /> | <video src="https://github.com/user-attachments/assets/294fb1ac-dc23-462e-aef2-c296c1104cdc" /> |





### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
