### PR TITLE
feat(swap): set default firebase swap flag to true

### DIFF
--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -22,7 +22,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: false,
   coinbasePayEnabled: false,
-  showSwapMenuInDrawerMenu: false,
+  showSwapMenuInDrawerMenu: true,
   maxSwapSlippagePercentage: 2,
   networkTimeoutSeconds: 30,
   celoNews: JSON.stringify({} as RemoteConfigValues['celoNews']),

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -180,7 +180,7 @@ describe('store state', () => {
           "sentryTracesSampleRate": 0.2,
           "sessionId": "",
           "showNotificationSpotlight": true,
-          "showSwapMenuInDrawerMenu": false,
+          "showSwapMenuInDrawerMenu": true,
           "supportedBiometryType": null,
           "walletConnectV2Enabled": true,
         },


### PR DESCRIPTION
### Description

Per conversation here. https://www.figma.com/design/PzsUxBv03Kg6GgzsSq5R1D?node-id=2143-22316#1032629938, sets the flag that shows/hides swaps to true

### Test plan

Do an fresh install and token details include swap as an action

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
