### PR TITLE
chore(tests): Disable e2e tests and failing points test

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   android:
-    if: true
+    if: false
     name: Android
     uses: ./.github/workflows/e2e-android.yml
     with:

--- a/src/points/PointsHistoryBottomSheet.test.tsx
+++ b/src/points/PointsHistoryBottomSheet.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import { PointsEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { PointsEvents } from 'src/analytics/Events'
 import PointsHistoryBottomSheet from 'src/points/PointsHistoryBottomSheet'
 import { getHistoryStarted } from 'src/points/slice'
 import { GetHistoryResponse } from 'src/points/types'
@@ -106,7 +106,7 @@ describe(PointsHistoryBottomSheet, () => {
     expect(tree.getByTestId('PointsHistoryBottomSheet/Empty')).toBeTruthy()
   })
 
-  it('displays content while loading', async () => {
+  it.skip('displays content while loading', async () => {
     const tree = renderScreen({
       points: { pointsHistory: MOCK_RESPONSE_NO_NEXT_PAGE.data, getHistoryStatus: 'loading' },
     })


### PR DESCRIPTION
### Description

We are doing throw away work for a few days and then, if we do more work on this app, we will move to the divvy framework. The e2e tests were failing on main and not worth fixing right now.